### PR TITLE
Increase Ruby line length to 120

### DIFF
--- a/lib/generators/lint_configs/templates/.rubocop.yml
+++ b/lib/generators/lint_configs/templates/.rubocop.yml
@@ -1,7 +1,7 @@
 require: rubocop-rspec
 
 LineLength:
-  Max: 100
+  Max: 120
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
# Problem
`100` character limit is quite constricting in ruby especially with descriptive method names and chained methods in Arel.

# Solution
We have talked about increasing the line limit. This increases it to `120`, which should be small enough to render a `.rb` and `_spec.rb` file side by side.

@shopsmart/web-team 