### PR TITLE
Exclude RSpec and other DSl's from block rule

### DIFF
--- a/lib/generators/lint_configs/templates/.rubocop.yml
+++ b/lib/generators/lint_configs/templates/.rubocop.yml
@@ -25,3 +25,10 @@ Style/TrailingBlankLines:
 
 AmbiguousBlockAssociation:
   Enabled: false
+
+# Ignore These paths when checking for block lengths since DSLs are still ok in ruby style guide
+Style/BlockLength:
+  Exclude:
+    - "Rakefile"
+    - "**/*.rake"
+    - "spec/**/*.rb"

--- a/lib/generators/lint_configs/templates/.rubocop.yml
+++ b/lib/generators/lint_configs/templates/.rubocop.yml
@@ -29,6 +29,7 @@ AmbiguousBlockAssociation:
 # Ignore These paths when checking for block lengths since DSLs are still ok in ruby style guide
 Style/BlockLength:
   Exclude:
+    - "config/routes.rb"
     - "Rakefile"
     - "**/*.rake"
     - "spec/**/*.rb"


### PR DESCRIPTION
# Problem
This cop is aimed at large block in the imperative programming sense. As a general guide, it does not apply to DSLs, which are often declarative. For example, having a long routes.rb file in Rails is perfectly benign. It's just a natural result of a large application, rather than a style violation. (And having a lot of tests is purely awesome.)

Now, RuboCop is pretty smart, but it doesn't know what is a DSL and not, so we can't automatically ignore them. One could argue that we could exclude DSL entry methods of popular frameworks, like Rails routes and RSpec specs. The reasons for not doing so are primarily:

- False negatives. Any class can implement a method, taking a block, with the same name.
- RuboCop is a Ruby analysis tool, and shouldn't really know about external libraries. (Excluding the /spec directory is a courtesy until we have a proper extension system, and this can be handled by the rubocop-rspec gem.)

# Solution
Add a list of excluded paths and files we know should and do allow for large DSL block declarations.

@shopsmart/web-team 