### PR TITLE
Increase nesting and make RSPEC specific configs clear

### DIFF
--- a/lib/generators/lint_configs/templates/.rubocop.yml
+++ b/lib/generators/lint_configs/templates/.rubocop.yml
@@ -25,3 +25,8 @@ Style/TrailingBlankLines:
 
 AmbiguousBlockAssociation:
   Enabled: false
+
+######################################## RSpec Specific #############################################
+
+RSpec/NestedGroups:
+  MaxNesting: 4

--- a/lib/generators/lint_configs/templates/.rubocop.yml
+++ b/lib/generators/lint_configs/templates/.rubocop.yml
@@ -29,4 +29,4 @@ AmbiguousBlockAssociation:
 ######################################## RSpec Specific #############################################
 
 RSpec/NestedGroups:
-  MaxNesting: 4
+  Max: 4


### PR DESCRIPTION
# Problem
Our typical structure for Rspec tests is to have a class block followed by method specific blocks, which leads to only one extra block level allowed after our base structure. After speaking with @sypher7 it seems preferable to allow for a least two additional levels.

# Solution
This changes the max from `3` to `4`.

@shopsmart/web-team 