### PR TITLE
Add pre-commit ignore file to generator to ignore vcr yml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ mkmf.log
 
 # Ignore Cucumber Re-run
 rerun.txt
+
+# Coverage
+test_app/coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,12 @@ env:
 cache:
   - bundler
   - apt
-script:
+before_script:
   - cd test_app
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
+script:
   - bundle exec rspec
+after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,17 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.3
-script:
+env:
+  global:
+    - CC_TEST_REPORTER_ID=83a4a2047d4dee163903b2d6495d25ecabd8087a226b040650eb435bb126a6f0
+before_script:
   - cd test_app
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+script:
   - bundle exec rspec
 cache:
   - bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: ruby
+rvm:
+  - 2.3.3
+script:
+  - cd test_app
+  - bundle exec rspec
+cache:
+  - bundler
+  - apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,14 @@ rvm:
   - 2.3.3
 env:
   global:
-    - CC_TEST_REPORTER_ID=83a4a2047d4dee163903b2d6495d25ecabd8087a226b040650eb435bb126a6f0
-before_script:
+    - CC_TEST_REPORTER_ID="83a4a2047d4dee163903b2d6495d25ecabd8087a226b040650eb435bb126a6f0"
+cache:
+  - bundler
+  - apt
+script:
   - cd test_app
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
-after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-script:
   - bundle exec rspec
-cache:
-  - bundler
-  - apt
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gemspec
 group :development, :test do
   gem "rails", require: false
   gem "rspec-rails", require: false
+  gem "simplecov", require: false, group: :test
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
     concurrent-ruby (1.0.5)
     crass (1.0.3)
     diff-lcs (1.3)
+    docile (1.1.5)
     erubi (1.7.0)
     execjs (2.7.0)
     ffi (1.9.18)
@@ -69,6 +70,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
+    json (2.1.0)
     loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -162,6 +164,11 @@ GEM
     scss_lint (0.56.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.3)
+    simplecov (0.15.1)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -195,6 +202,7 @@ DEPENDENCIES
   rubocop
   rubocop-rspec
   scss_lint
+  simplecov
   thor
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/765a8008543a6d0293df/maintainability)](https://codeclimate.com/github/shopsmart/bd_lint/maintainability)
-
+[![Build Status](https://travis-ci.org/shopsmart/bd_lint.svg?branch=master)](https://travis-ci.org/shopsmart/bd_lint)
 # BdLint
 Short description and motivation.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/765a8008543a6d0293df/maintainability)](https://codeclimate.com/github/shopsmart/bd_lint/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/765a8008543a6d0293df/test_coverage)](https://codeclimate.com/github/shopsmart/bd_lint/test_coverage)
 [![Build Status](https://travis-ci.org/shopsmart/bd_lint.svg?branch=master)](https://travis-ci.org/shopsmart/bd_lint)
+
 # BdLint
 Short description and motivation.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Maintainability](https://api.codeclimate.com/v1/badges/765a8008543a6d0293df/maintainability)](https://codeclimate.com/github/shopsmart/bd_lint/maintainability)
+
 # BdLint
 Short description and motivation.
 

--- a/lib/generators/lint_configs/lint_configs_generator.rb
+++ b/lib/generators/lint_configs/lint_configs_generator.rb
@@ -2,8 +2,9 @@ class LintConfigsGenerator < Rails::Generators::Base
   source_root File.expand_path('../templates', __FILE__)
 
   def copy_lint_configs
-    copy_file ".jscsrc",        ".jscsrc"
-    copy_file ".rubocop.yml",   ".rubocop.yml"
-    copy_file ".scss-lint.yml", ".scss-lint.yml"
+    copy_file ".jscsrc",            ".jscsrc"
+    copy_file ".pre_commit.ignore", ".pre_commit.ignore"
+    copy_file ".rubocop.yml",       ".rubocop.yml"
+    copy_file ".scss-lint.yml",     ".scss-lint.yml"
   end
 end

--- a/lib/generators/lint_configs/lint_configs_generator_basic.rb
+++ b/lib/generators/lint_configs/lint_configs_generator_basic.rb
@@ -8,8 +8,9 @@ class LintConfigsGeneratorBasic < Thor::Group
   end
 
   def copy_lint_configs
-    copy_file ".jscsrc",        ".jscsrc"
-    copy_file ".rubocop.yml",   ".rubocop.yml"
-    copy_file ".scss-lint.yml", ".scss-lint.yml"
+    copy_file ".jscsrc",            ".jscsrc"
+    copy_file ".pre_commit.ignore", ".pre_commit.ignore"
+    copy_file ".rubocop.yml",       ".rubocop.yml"
+    copy_file ".scss-lint.yml",     ".scss-lint.yml"
   end
 end

--- a/lib/generators/lint_configs/templates/.pre_commit.ignore
+++ b/lib/generators/lint_configs/templates/.pre_commit.ignore
@@ -1,0 +1,1 @@
+spec/cassettes/**/*.yml

--- a/spec/lib/generators/lint_configs/lint_configs_generator_spec.rb
+++ b/spec/lib/generators/lint_configs/lint_configs_generator_spec.rb
@@ -17,7 +17,7 @@ describe LintConfigsGenerator do
       subject.invoke_all
 
       files      = Dir[Rails.root.join(".*")]
-      file_names = files.map{ |f| f.split("/").pop }
+      file_names = files.map { |f| f.split("/").pop }
 
       expect(file_names).to include(*lint_configs)
     end

--- a/spec/lib/generators/lint_configs/lint_configs_generator_spec.rb
+++ b/spec/lib/generators/lint_configs/lint_configs_generator_spec.rb
@@ -4,7 +4,7 @@ require "rails/generators"
 require "generators/lint_configs/lint_configs_generator"
 
 describe LintConfigsGenerator do
-  let(:lint_configs) { %w[.jscsrc .rubocop.yml .scss-lint.yml] }
+  let(:lint_configs) { %w[.jscsrc .rubocop.yml .scss-lint.yml .pre_commit.ignore] }
 
   describe "#copy_lint_configs" do
     after do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,9 @@ require File.expand_path("../../config/environment", __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'simplecov'
+
+SimpleCov.start
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
Add a `.pre_commit.ignore` file to the list of generated files so not only can cassettes be ignored by default but a repo can also add other vendors specific generated files to the list.

@shopsmart/web-team 