### PR TITLE
Enforce Linter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bd_lint (0.2.1.4)
+    bd_lint (0.2.2)
       brakeman
       bundler-audit
       execjs
@@ -206,4 +206,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/lib/bd_lint.rb
+++ b/lib/bd_lint.rb
@@ -1,10 +1,14 @@
 require "bd_lint/rvm_version"
+require "bd_lint/validator"
 require "pre-commit"
 require "plugins/pre_commit/checks/jscs"
 
+# Run this on application initialization
+BdLint::Validator.check
+BdLint::RvmVersion.check
+
 module BdLint
   def self.run
-    RvmVersion.check
     PreCommit.run
   end
 end

--- a/lib/bd_lint/rvm_version.rb
+++ b/lib/bd_lint/rvm_version.rb
@@ -1,7 +1,7 @@
+require "mkmf"
+
 module BdLint
   class RvmVersion
-    require "mkmf"
-
     def self.check
       if MakeMakefile.find_executable("rvm")
         rvm_current = %x(rvm current).chomp

--- a/lib/bd_lint/validator.rb
+++ b/lib/bd_lint/validator.rb
@@ -1,0 +1,15 @@
+module BdLint
+  class Validator
+    GIT_HOOK_PATH = ".git/hooks/pre-commit".freeze
+
+    class GitHookError < StandardError; end
+
+    def self.check
+      raise GitHookError, "Please run `bundle exec rake bd_lint:generate:pre_commit`" if invalid?
+    end
+
+    def self.invalid?
+      !defined?(Rake) && !File.exist?(GIT_HOOK_PATH)
+    end
+  end
+end

--- a/lib/bd_lint/validator.rb
+++ b/lib/bd_lint/validator.rb
@@ -5,11 +5,15 @@ module BdLint
     class GitHookError < StandardError; end
 
     def self.check
-      raise GitHookError, "Please run `bundle exec rake bd_lint:generate:pre_commit`" if invalid?
+      raise GitHookError, "Please run `bundle exec #{message}`" if invalid?
     end
 
     def self.invalid?
       !defined?(Rake) && !File.exist?(GIT_HOOK_PATH)
+    end
+
+    def self.message
+      defined?(Rails) ? "rails g pre_commit" : "rake bd_lint:generate:pre_commit"
     end
   end
 end

--- a/lib/bd_lint/version.rb
+++ b/lib/bd_lint/version.rb
@@ -1,3 +1,3 @@
 module BdLint
-  VERSION = "0.2.1.4".freeze
+  VERSION = "0.2.2".freeze
 end

--- a/test_app/config/application.rb
+++ b/test_app/config/application.rb
@@ -6,6 +6,8 @@ require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
+# Prevents test from not running
+require "rake"
 # require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups)


### PR DESCRIPTION
This PR provides a better guiding hand in setting up development environments with BD Lint. It will raise an error and prevent the app from booting in development and tests until the developer has run the necessary commands to tie in the required git hooks.

@shopsmart/web-team 