### PR TITLE
Use bash shell for script

### DIFF
--- a/lib/generators/pre_commit/templates/pre-commit
+++ b/lib/generators/pre_commit/templates/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # This hook has a focus on portability.
 # This hook will attempt to setup your environment before running checks.


### PR DESCRIPTION
# Problem
Line 15 in the pre-commit script is not POSIX-compliant and will break on systems that do not symlink /bin/sh => /bin/bash (i.e. most modern Linux distributions).

# Solution
Just use bash for the script.

@shopsmart/web-team 