### PR TITLE
Use the current rvm instead of default

### DIFF
--- a/lib/generators/pre_commit/templates/pre-commit
+++ b/lib/generators/pre_commit/templates/pre-commit
@@ -24,7 +24,7 @@ cmd=`git config pre-commit.ruby 2>/dev/null`
 if   test -n "${cmd}"
 then true
 elif which rvm   >/dev/null 2>/dev/null
-then cmd="bundle exec rvm default do ruby"
+then cmd="rvm current do ruby"
 elif which rbenv >/dev/null 2>/dev/null
 then cmd="rbenv exec ruby"
 else cmd="bundle exec ruby"


### PR DESCRIPTION
# Problem
Current pre-commit script will look for the default rvm ruby instead of the one associated with the project. If they are different, and the ruby version is specified in the Gemfile, this can cause commits to blow up.

# Solution
Do not need to wrap this in bundle exec (it is not a gem script/binary). Use `current` instead of `default` with `do ruby` so that we get the ruby version associated with the project trying to make the commit instead of the default ruby, which might be a mismatch and cause the pre-commit script to blow up.

@shopsmart/web-team 