### PR TITLE
Bump version after bug fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,6 @@ group :development do
   gem "bundler-audit", require: false
   gem "execjs"
   gem "pre-commit"
-  # gem "pry-rails", require: false
-  # gem "rspec-rails", require: false
   gem "pry"
   gem "rspec"
   gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bd_lint (0.2.2)
+    bd_lint (0.2.2.1)
       brakeman
       bundler-audit
       execjs

--- a/lib/bd_lint/version.rb
+++ b/lib/bd_lint/version.rb
@@ -1,3 +1,3 @@
 module BdLint
-  VERSION = "0.2.2".freeze
+  VERSION = "0.2.2.1".freeze
 end


### PR DESCRIPTION
Bump Version to `0.2.2.1` with bugfix.

Goal to bring back inline release versions with gem version 

@shopsmart/web-team 
