### PR TITLE
Remove duplicate rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development do
   gem "execjs"
   gem "pre-commit"
   gem "pry"
+  gem "rspec"
   gem "rubocop"
   gem "rubocop-rspec"
   gem "scss_lint"

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ group :development do
   gem "execjs"
   gem "pre-commit"
   gem "pry"
-  gem "rspec"
   gem "rubocop"
   gem "rubocop-rspec"
   gem "scss_lint"

--- a/bd_lint.gemspec
+++ b/bd_lint.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |s|
   s.add_dependency "thor"
 
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec"
 end


### PR DESCRIPTION
rspec is not a development dependency of the host apps, so it shouldn't included in the gemspec.

@shopsmart/web-team 