### PR TITLE
Prefer alias method over alias

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -100,7 +100,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.1)
@@ -216,4 +216,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/lib/generators/lint_configs/templates/.rubocop.yml
+++ b/lib/generators/lint_configs/templates/.rubocop.yml
@@ -38,6 +38,8 @@ Metrics:
 Style/Lambda:
   EnforcedStyle: literal
 
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
 
 ######################################## RSpec Specific #############################################
 


### PR DESCRIPTION
## Updates

We have historically enforced the preference of `alias_method` over `alias` in all cases. This PR adds the override to enforce that preference.

This PR also updates loofah and rack dependencies due to vulnerabilities.

@shopsmart/web-team 