### PR TITLE
Bugfix/audit default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bd_lint (0.4.0)
+    bd_lint (0.4.1)
       brakeman
       bundler-audit
       execjs

--- a/lib/bd_lint/audit/cli.rb
+++ b/lib/bd_lint/audit/cli.rb
@@ -12,7 +12,7 @@ module BdLint
       def check
         if ENV["DISABLE_BUNDLE_AUDIT"]
           DISABLED_WARNING.each { |msg| say msg, :yellow }
-          exit 0
+          return
         end
 
         super

--- a/lib/bd_lint/version.rb
+++ b/lib/bd_lint/version.rb
@@ -1,3 +1,3 @@
 module BdLint
-  VERSION = "0.4.0".freeze
+  VERSION = "0.4.1".freeze
 end

--- a/lib/tasks/bd_lint.rake
+++ b/lib/tasks/bd_lint.rake
@@ -21,8 +21,6 @@ namespace :bd_lint do
         BdLint::Audit::CLI.start [command]
       end
     end
-
-    task default: "bd_lint:audit"
   rescue LoadError
     puts "Bundle Audit Gem not loaded. Nothing to do"
   end
@@ -39,3 +37,6 @@ namespace :bd_lint do
     end
   end
 end
+
+# Make audit a default task if defined
+task default: "bd_lint:audit" if Rake::Task.task_defined?("bd_lint:audit")

--- a/spec/lib/tasks/bd_lint_spec.rb
+++ b/spec/lib/tasks/bd_lint_spec.rb
@@ -23,6 +23,8 @@ end
 describe "bd_lint:audit" do
   include_context "rake"
 
+  let(:default_task) { Rake::Task.tasks.find { |t| t.name.eql?("default") } }
+
   it "calls update" do
     expect_any_instance_of(BdLint::Audit::CLI).to receive(:update)
     subject.invoke
@@ -34,9 +36,13 @@ describe "bd_lint:audit" do
   end
 
   it "scans Gemfile.lock" do
-      expect_any_instance_of(Bundler::Audit::Scanner).to receive(:scan).and_call_original
-      subject.invoke
-    end
+    expect_any_instance_of(Bundler::Audit::Scanner).to receive(:scan).and_call_original
+    subject.invoke
+  end
+
+  it "is part of the default rake tasks" do
+    expect(default_task.prerequisite_tasks.map(&:name)).to include "bd_lint:audit"
+  end
 
   context "when the DISABLE_BUNDLE_AUDIT is set" do
     before do

--- a/test_app/Gemfile.lock
+++ b/test_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    bd_lint (0.3.0)
+    bd_lint (0.4.1)
       brakeman
       bundler-audit
       execjs


### PR DESCRIPTION
# Problem
The default task was incorrectly defined inside the bd_lint namespace causing rake to not auto-execute the audit.

Also exiting from task during the bypass causes the tests to be skipped as well.

# Solution
Defined the default task outside any namespaces.

Simply return from the method if the `DISABLE_BUNDLE_AUDIT` is set

@shopsmart/web-team 