### PR TITLE
Bundle audit ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.6.0
+
+Changes:
+
+  - Adds `BUNDLE_AUDIT_IGNORE` ENVAR to support ignoring specific CVE's
+
+Documentation:
+
+  - Updated README with `BUNDLE_AUDIT_IGNORE` section
+
 ## v0.5.0
 
 Changes:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bd_lint (0.5.0)
+    bd_lint (0.6.0)
       brakeman
       bundler-audit
       execjs
@@ -216,4 +216,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ If you are trying to merge or push a change out and temporarily ignore bundle au
 #### Note
 If you are merging a pull requests and deploying to staging wait until after your code is deployed before removing the variable from Travis.
 
+If a gem has an open CVE with no viable long term fix and we need to ignore it without skipping all gems set the `BUNDLE_AUDIT_IGNORE` as a comma delimited value of CVE's
+
+1. Vist your Travis builds Repository
+2. Click `More options` / `Settings`
+3. Go to the `Environment Variables` section
+4. Add `BUNDLE_AUDIT_IGNORE` with a comma delimited list of CVE's
+5. Re-run your travis build
+
 ## Additional Commands
 
 #### Evaluate Changes Manually

--- a/lib/bd_lint/audit/cli.rb
+++ b/lib/bd_lint/audit/cli.rb
@@ -15,6 +15,12 @@ module BdLint
           return
         end
 
+        # Parse ignored list
+        ignore = ENV["BUNDLE_AUDIT_IGNORE"]&.split(",")
+
+        # Merge ignored into options
+        self.options = self.options.merge(ignore: ignore)
+
         super
       end
     end

--- a/lib/bd_lint/version.rb
+++ b/lib/bd_lint/version.rb
@@ -1,3 +1,3 @@
 module BdLint
-  VERSION = "0.5.0".freeze
+  VERSION = "0.6.0".freeze
 end


### PR DESCRIPTION
# Problem
We need to be able to ignore certain CVE's at times where a fix in the gem is not quick enough and we have a way to mitigate the issue or the issue simply does not apply to us.

# Solution
Add a `BUNDLE_AUDIT_INGORE` ENVAR that takes a comma-delimited string of CVE's for the repo to ignore.

We can set these in Travis or with the `test` environment files if we wish to version control.

@shopsmart/web-team 