### PR TITLE
Force Rubocop Upgrade to Resolve Frozen Literal Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.7.1
+Changes:
+
+  - Push Rucocop past version 0.9.0 to escape know frozen string literal bug
+
+
 ## v0.7.0
 
 Changes:

--- a/bd_lint.gemspec
+++ b/bd_lint.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "brakeman", "~> 4"
-  s.add_dependency "bundler-audit", "~> 0.6"
+  s.add_dependency "bundler-audit", "~> 0.7"
   s.add_dependency "execjs"
-  s.add_dependency "pre-commit", "0.39.0"
-  s.add_dependency "rubocop", "0.79.0"
-  s.add_dependency "rubocop-rspec", "~> 1.37"
+  s.add_dependency "fasterer", "~> 0.6"
+  s.add_dependency "rubocop", "~> 0.93.1"
+  s.add_dependency "rubocop-rspec", "~> 1.43"
   s.add_dependency "scss_lint", "0.59.0"
   s.add_dependency "thor"
 

--- a/bd_lint.gemspec
+++ b/bd_lint.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "bundler-audit", "~> 0.7"
   s.add_dependency "execjs"
   s.add_dependency "fasterer", "~> 0.6"
+  s.add_dependency "pre-commit", "0.39.0"
   s.add_dependency "rubocop", "~> 0.93.1"
   s.add_dependency "rubocop-rspec", "~> 1.43"
   s.add_dependency "scss_lint", "0.59.0"

--- a/lib/generators/lint_configs/templates/.rubocop.yml
+++ b/lib/generators/lint_configs/templates/.rubocop.yml
@@ -1,5 +1,8 @@
 require: rubocop-rspec
 
+AllCops:
+  NewCops: enable
+
 Layout/LineLength:
   Max: 120
 
@@ -9,7 +12,7 @@ Style/StringLiterals:
 Style/Copyright:
   Enabled: false
 
-Style/Documentation :
+Style/Documentation:
   Enabled: false
 
 # http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FrozenStringLiteralComment
@@ -20,7 +23,7 @@ Style/Documentation :
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 Lint/AmbiguousBlockAssociation:


### PR DESCRIPTION
# Problem
It's time for Rubocop to get an upgrade. The version we are on has a known issue we should force versions beyond that point.

# Solution
Upgrade Rubocop, Rubocop RSpec, Fasterer
Update the Rubocop template.

@shopsmart/web-team 