### PR TITLE
Adds github settings configurations and sets the default branch to main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+.github/settings.yml  @shopsmart/tech-ops-team
+
+# Everything needs to be approved through the web team
+*        @shopsmart/web-team
+

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,48 @@
+repository:
+  name: bd_lint
+  description: null
+  homepage: null
+  topics: ''
+  private: false
+  has_issues: true
+  has_projects: true
+  has_wiki: true
+  has_downloads: true
+  default_branch: master
+  allow_squash_merge: true
+  allow_merge_commit: true
+  allow_rebase_merge: true
+  enable_automated_security_fixes: true
+  enable_vulnerability_alerts: true
+teams:
+  - name: deploy
+    permission: pull
+  - name: developers
+    permission: push
+  - name: tech-ops-team
+    permission: admin
+  - name: web-team
+    permission: admin
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        dismissal_restrictions: {}
+      required_status_checks: null
+      enforce_admins: false
+      required_linear_history: false
+      restrictions: null
+  - name: '*-base'
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        dismissal_restrictions: {}
+      required_status_checks: null
+      enforce_admins: false
+      required_linear_history: false
+      restrictions: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -8,7 +8,7 @@ repository:
   has_projects: true
   has_wiki: true
   has_downloads: true
-  default_branch: master
+  default_branch: main
   allow_squash_merge: true
   allow_merge_commit: true
   allow_rebase_merge: true
@@ -31,7 +31,11 @@ branches:
         dismiss_stale_reviews: false
         require_code_owner_reviews: true
         dismissal_restrictions: {}
-      required_status_checks: null
+      required_status_checks:
+        strict: false
+        contexts:
+          - Travis CI - Branch
+          - Travis CI - Pull Request
       enforce_admins: false
       required_linear_history: false
       restrictions: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -35,7 +35,7 @@ branches:
       enforce_admins: false
       required_linear_history: false
       restrictions: null
-  - name: '*-base'
+  - name: '*base'
     protection:
       required_pull_request_reviews:
         required_approving_review_count: 2


### PR DESCRIPTION
## Problem
<!-- What are you trying to solve? -->

We want Github settings to be properly configured across the organization.

## Solution
<!-- How does this solve the problem? -->

The [Settings App](https://github.com/probot/settings) can help us manage our Github settings through code.  Not only will this version our settings, it will enable developers to add configurations by simply putting in a PR.  It can help manage labels for us as well which will come in handy if we want to enable auto versioning via tag labels.  The code owners file will enforce that the Tech Ops Team needs to approve a change to the settings.